### PR TITLE
DL-3571 - Unit tests failing for professional-subscriptions-frontend

### DIFF
--- a/test/controllers/CheckYourAnswersControllerSpec.scala
+++ b/test/controllers/CheckYourAnswersControllerSpec.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import base.SpecBase
-import models.PSubsByYear
+import models.{NpsDataFormats, PSubsByYear}
 import models.TaxYearSelection._
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.Mockito._
@@ -75,7 +75,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with MockitoSugar with Sca
       ))
 
       val subscriptions: Seq[AnswerSection] = {
-        ua.get(SummarySubscriptionsPage)(PSubsByYear.pSubsByYearFormats).get.zipWithIndex.flatMap {
+        NpsDataFormats.sort(ua.get(SummarySubscriptionsPage)(PSubsByYear.pSubsByYearFormats).get).zipWithIndex.flatMap {
           case (psubsByYear, yearIndex) =>
             psubsByYear._2.zipWithIndex.map {
               case (psub, subIndex) =>
@@ -93,7 +93,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with MockitoSugar with Sca
                   messageArgs = Seq(taxYear.toString, (taxYear + 1).toString): _*
                 )
             }
-        }.toSeq
+        }
       }
 
       val application = applicationBuilder(userAnswers = Some(ua)).build()


### PR DESCRIPTION
# DL-3571 - Unit tests failing for professional-subscriptions-frontend

Unit tests in `CheckYourAnswersControllerSpec` failed for years ending in zero (e.g. 2020, 2010, 1990), where the order of the `Seq[AnswerSection]` would differ from what's generated by the frontend.
Changed unit test to explicitly sort answers.

## Checklist

*Stephen*
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
