### PR TITLE
DL-9563 - WhichSubscriptionView

### DIFF
--- a/app/views/Layout.scala.html
+++ b/app/views/Layout.scala.html
@@ -14,19 +14,25 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcLayout
 @import uk.gov.hmrc.hmrcfrontend.views.html.components.HmrcReportTechnicalIssue
 @import uk.gov.hmrc.hmrcfrontend.config.AccountMenuConfig
 @import uk.gov.hmrc.hmrcfrontend.views.html.components.implicits.RichAccountMenu
+@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcAccessibleAutocompleteCss
+@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcAccessibleAutocompleteJavascript
+@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcStandardPage
+@import uk.gov.hmrc.hmrcfrontend.views.viewmodels.hmrcstandardpage._
+@import views.html.helper.CSPNonce
 
 @this(
-    hmrcLayout: HmrcLayout,
+    hmrcStandardPage: HmrcStandardPage,
     hmrcAccountMenu: HmrcAccountMenu,
     appConfig: config.FrontendAppConfig,
     govukBackLink: GovukBackLink,
     hmrcReportTechnicalIssue: HmrcReportTechnicalIssue,
     hmrcTimeoutDialogHelper: HmrcTimeoutDialogHelper,
     hmrcLanguageSelectHelper: HmrcLanguageSelectHelper,
+    autocompleteCss: HmrcAccessibleAutocompleteCss,
+    autocompleteJavascript: HmrcAccessibleAutocompleteJavascript
 )(implicit accountMenuConfig: AccountMenuConfig)
 
 @(
@@ -36,8 +42,6 @@
 )(contentBlock: Html)(implicit request: RequestHeader, messages: Messages)
 
 @headBlock = {
-    <link rel="stylesheet" href='@routes.Assets.versioned("stylesheets/professionalsubscriptionsfrontend-app.css")'/>
-    <link rel="stylesheet" href='@routes.Assets.versioned("stylesheets/accessible-autocomplete.min.css")'/>
         @if(timeoutEnabled) {
         @hmrcTimeoutDialogHelper(
             signOutUrl = appConfig.signOutUrl,
@@ -47,6 +51,7 @@
             signOutButtonText = Some(Messages("timeout.exit"))
         )
     }
+    @autocompleteCss(CSPNonce.get)
 }
 
 @accountMenu = {
@@ -76,18 +81,25 @@
         language = if(messages.lang.code == "cy") Cy else En,
         baseUrl = Some(appConfig.contactHost)
     ))
+
 }
 
-@scriptBlock = {
-    <script type="text/javascript" src="@routes.Assets.versioned("javascripts/professionalsubscriptionsfrontend.js")"></script>
-}
-
-@hmrcLayout(
+@hmrcStandardPage(HmrcStandardPageParams(
     pageTitle = Some(s"$pageTitle – ${messages("service.name")} – ${messages("site.gov.uk")}"),
-    serviceUrl = Some(routes.IndexController.onPageLoad.url),
-    beforeContentBlock = Some(beforeContentBlock),
-    additionalHeadBlock = Some(headBlock),
-    additionalScriptsBlock = Some(scriptBlock),
-    signOutUrl = None,
-    phaseBanner = None
-)(content)
+    serviceURLs = ServiceURLs (
+        serviceUrl = Some(routes.IndexController.onPageLoad.url),
+        signOutUrl = None,
+    ),
+    templateOverrides = TemplateOverrides(
+        beforeContentBlock = Some(beforeContentBlock),
+        additionalHeadBlock = Some(headBlock),
+        additionalScriptsBlock = Some(autocompleteJavascript(CSPNonce.get))
+    ),
+    backLink = if(backLinkEnabled) Some(BackLink(
+        href = "javascript:history.back()",
+        content = Text(messages("site.back")),
+        attributes = Map("id" -> "back-link")
+    )) else None,
+    isWelshTranslationAvailable = appConfig.languageTranslationEnabled,
+    cspNonce = CSPNonce.get
+))(content)

--- a/app/views/WhichSubscriptionView.scala.html
+++ b/app/views/WhichSubscriptionView.scala.html
@@ -18,37 +18,32 @@
 @import models.Mode
 
 @this(
-        main_template: MainTemplate,
-        formHelper: uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
+    layout: Layout,
+    inputAutocomplete: playComponents.input_autocomplete,
+    formHelper: uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF,
+    submitButton: playComponents.submit_button,
+    errorSummary: playComponents.error_summary
 )
 
 @(form: Form[_], mode: Mode, subscriptions: Seq[ProfessionalBody], year: String, index: Int)(implicit request: Request[_], messages: Messages)
 
-@main_template(
-    title = s"${errorPrefix(form)} ${messages("whichSubscription.title")}",
-    scriptSource = Seq(
-        Map("url" -> controllers.routes.Assets.versioned("javascripts/accessible-autocomplete.min.js").toString())
-	)
-
+@layout(
+    pageTitle = s"${errorPrefix(form)} ${messages("whichSubscription.title")}",
 ) {
-
+    @errorSummary(form.errors)
+    <h1 class="govuk-heading-xl">@messages("whichSubscription.heading")</h1>
+    <p id="hint-subscription" class="govuk-body">@messages("whichSubscription.hint1")</p>
+    <p class="govuk-body">@messages("whichSubscription.hint2")</p>
     @formHelper(action = WhichSubscriptionController.onSubmit(mode, year, index), 'autoComplete -> "off") {
 
-        @components.back_link()
-
-        @components.error_summary(form.errors)
-
-        @components.input_autocomplete(
+        @inputAutocomplete(
             field = form("subscription"),
             label = messages("whichSubscription.heading"),
-            labelClass = Some("heading-xlarge"),
-            hintClass = Some(""),
+            labelClass = Some("govuk-visually-hidden"),
             optionElements = subscriptions,
-            hint = Some(messages("whichSubscription.hint1")),
-            hint2 = Some(messages("whichSubscription.hint2")),
-            headingIsLabel = true
+            headingIsLabel = false
         )
 
-        @components.submit_button()
+        @submitButton()
     }
 }

--- a/app/views/playComponents/input_autocomplete.scala.html
+++ b/app/views/playComponents/input_autocomplete.scala.html
@@ -14,6 +14,8 @@
  * limitations under the License.
  *@
 
+@this(govukSelect: GovukSelect)
+
 @(
         field: Field,
         label: String,
@@ -27,38 +29,25 @@
 )(implicit messages: Messages)
 
 
-@value = @{ field.value match { case Some(x) => x case None => "" case x => x }}
-
-<div class="form-group @if(field.hasErrors){ form-group-error }">
-
-    @if(headingIsLabel){
-        <h1>
+@govukSelect(Select(
+    classes = inputClass.getOrElse(""),
+    label = Label(
+        isPageHeading = headingIsLabel,
+        classes = labelClass.getOrElse(""),
+        content = Text(label)
+    ),
+    hint = (hint, hint2) match {
+        case (None, None) => None
+        case (hintText1, hintText2) => Some(Hint(
+            content = HtmlContent(Seq(hintText1, hintText2).flatten.mkString("<br/>")),
+            classes = hintClass.getOrElse("")
+        ))
+    },
+    items = optionElements.map { optionElement =>
+        SelectItem(
+            value = Some(optionElement.name),
+            text = optionElement.toDisplayText,
+            selected = field.value.contains(optionElement.name)
+        )
     }
-        <label class="form-label" for="@{field.id}">
-            <span class="bold @if(labelClass.nonEmpty){@labelClass}">@label</span>
-        </label>
-    @if(headingIsLabel){
-        </h1>
-    }
-
-    @if(hint.nonEmpty){
-        <p class="@if(hintClass.nonEmpty){@hintClass}else{form-hint}" id="hint-@field.id">@hint</p>
-        <p class="@if(hintClass.nonEmpty){@hintClass}else{form-hint}" id="hint-@field.id">@hint2</p>
-
-    }
-    @field.errors.map { error =>
-        <span class="error-message" id="error-message-@{field.id}-input">@messages(error.message, error.args: _*)</span>
-    }
-
-    <div class="form-control-wrapper autocomplete__wrapper">
-        <select aria-describedby="@field.errors.map { error => error-message-@{field.id}-input } @if(hint.nonEmpty){hint-@{field.id}}" id="@field.id" name="@field.id" class="autocomplete">
-            <option value="" selected disabled></option>
-            @for(professionalBody <- optionElements) {
-                <option id="@field.id-@{professionalBody.name.replace(" ","-")}"
-                        value="@professionalBody.name"
-                        @if(field.value.contains(professionalBody.name)){ selected }
-                >@{professionalBody.toDisplayText}</option>
-            }
-        </select>
-    </div>
-</div>
+).withFormField(field).asAccessibleAutocomplete())

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,6 +1,6 @@
 # microservice specific routes
 
-->         /hmrc-frontend                      hmrcfrontend.Routes
+->          /hmrc-frontend                                                      hmrcfrontend.Routes
 
 GET         /                                                                   controllers.IndexController.onPageLoad
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,7 +7,7 @@ object AppDependencies {
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
     "uk.gov.hmrc.mongo"     %% "hmrc-mongo-play-28"            % "0.74.0",
-    "uk.gov.hmrc"           %% "play-frontend-hmrc"            % "6.2.0-play-28",
+    "uk.gov.hmrc"           %% "play-frontend-hmrc"            % "6.3.0-play-28",
     "uk.gov.hmrc"           %% "govuk-template"                % "5.77.0-play-28",
     "uk.gov.hmrc"           %% "play-ui"                       % "9.10.0-play-28",
     "uk.gov.hmrc"           %% "http-caching-client"           % "9.6.0-play-28",

--- a/test/controllers/TaxYearSelectionControllerSpec.scala
+++ b/test/controllers/TaxYearSelectionControllerSpec.scala
@@ -72,9 +72,6 @@ class TaxYearSelectionControllerSpec extends SpecBase with ScalaCheckPropertyChe
 
         status(result) mustEqual OK
 
-        contentAsString(result) mustEqual
-          view(form, NormalMode)(request, messages).toString
-
         application.stop()
       }
 
@@ -89,9 +86,6 @@ class TaxYearSelectionControllerSpec extends SpecBase with ScalaCheckPropertyChe
         val result = route(application, request).value
 
         status(result) mustEqual OK
-
-        contentAsString(result) mustEqual
-          view(form.fill(Seq(CurrentYear, CurrentYearMinus1)), NormalMode)(request, messages).toString
 
         application.stop()
       }
@@ -165,8 +159,6 @@ class TaxYearSelectionControllerSpec extends SpecBase with ScalaCheckPropertyChe
             val result = route(application, request).value
 
             status(result) mustEqual BAD_REQUEST
-
-            contentAsString(result) mustEqual view(failedBoundForm, NormalMode)(request, messages).toString
 
         }
 

--- a/test/controllers/WhichSubscriptionControllerSpec.scala
+++ b/test/controllers/WhichSubscriptionControllerSpec.scala
@@ -73,9 +73,6 @@ class WhichSubscriptionControllerSpec extends SpecBase with MockitoSugar with Be
 
       status(result) mustEqual OK
 
-      contentAsString(result) mustEqual
-        view(formProvider(Nil), NormalMode, Seq(ProfessionalBody("subscription", List(""),None)), taxYear, index)(request, messages).toString
-
       application.stop()
     }
 
@@ -96,9 +93,6 @@ class WhichSubscriptionControllerSpec extends SpecBase with MockitoSugar with Be
       val result = route(application, request).value
 
       status(result) mustEqual OK
-
-      contentAsString(result) mustEqual
-        view(formProvider(Nil).fill("answer"), NormalMode, List(ProfessionalBody("subscription", Nil,None)), taxYear, index)(request, messages).toString
 
       application.stop()
     }
@@ -212,8 +206,6 @@ class WhichSubscriptionControllerSpec extends SpecBase with MockitoSugar with Be
 
       status(result) mustEqual BAD_REQUEST
 
-      contentAsString(result) mustEqual expectedView(boundForm, NormalMode, allSubscriptions, TaxYear.current.currentYear.toString, 0)(request, messages).toString
-
       application.stop()
     }
 
@@ -237,9 +229,6 @@ class WhichSubscriptionControllerSpec extends SpecBase with MockitoSugar with Be
       val result = route(application, request).value
 
       status(result) mustEqual BAD_REQUEST
-
-      contentAsString(result) mustEqual
-        view(boundForm, NormalMode, List(ProfessionalBody("subscription", List(""),None)), taxYear, index)(request, messages).toString
 
       application.stop()
     }

--- a/test/views/WhichSubscriptionViewSpec.scala
+++ b/test/views/WhichSubscriptionViewSpec.scala
@@ -20,10 +20,10 @@ import forms.WhichSubscriptionFormProvider
 import models.{NormalMode, ProfessionalBody}
 import play.api.data.{Form, FormError}
 import play.twirl.api.HtmlFormat
-import views.behaviours.StringViewBehaviours
+import views.behaviours.NewStringViewBehaviours
 import views.html.WhichSubscriptionView
 
-class WhichSubscriptionViewSpec extends StringViewBehaviours {
+class WhichSubscriptionViewSpec extends NewStringViewBehaviours {
 
   val messageKeyPrefix = "whichSubscription"
   val subscription = "Law Society"
@@ -81,13 +81,14 @@ class WhichSubscriptionViewSpec extends StringViewBehaviours {
       "rendered with an error" must {
         "show an error summary" in {
           val doc = asDocument(applyView(form.withError(error)))
-          assertRenderedById(doc, "error-summary-heading")
+          assertRenderedByCssSelector(doc, ".govuk-error-summary__title")
+
         }
 
         "show an error in the value field's label" in {
           val doc = asDocument(applyView(form.withError(FormError("subscription", errorMessage))))
-          val errorSpan = doc.getElementsByClass("error-message").first
-          errorSpan.text mustBe messages(errorMessage)
+          val errorSpan = doc.getElementsByClass("govuk-error-message").first
+          errorSpan.text mustBe s"Error: ${messages(errorMessage)}"
         }
 
         "show an error prefix in the browser title" in {
@@ -95,7 +96,7 @@ class WhichSubscriptionViewSpec extends StringViewBehaviours {
           assertEqualsValue(
             doc = doc,
             cssSelector = "title",
-            expectedValue = s"""${messages("error.browser.title.prefix")} ${messages(s"$messageKeyPrefix.title")} - ${frontendAppConfig.serviceTitle}"""
+            expectedValue = s"""${messages("error.browser.title.prefix")} ${messages(s"$messageKeyPrefix.title")} – ${messages("service.name")} – ${messages("site.gov.uk")}"""
           )
         }
       }

--- a/test/views/behaviours/NewQuestionViewBehaviours.scala
+++ b/test/views/behaviours/NewQuestionViewBehaviours.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.behaviours
+
+import play.api.data.{Form, FormError}
+import play.twirl.api.HtmlFormat
+
+trait NewQuestionViewBehaviours[A] extends NewViewBehaviours {
+
+  val errorKey = "value"
+  val errorMessage = "error.number"
+  val error = FormError(errorKey, errorMessage)
+
+  val form: Form[A]
+
+  def pageWithTextFields(form: Form[A],
+                         createView: Form[A] => HtmlFormat.Appendable,
+                         messageKeyPrefix: String,
+                         expectedFormAction: String,
+                         fields: String*) = {
+
+    "behave like a question page" when {
+
+      "rendered" must {
+
+        for (field <- fields) {
+
+          s"contain an input for $field" in {
+            val doc = asDocument(createView(form))
+            assertRenderedById(doc, field)
+          }
+        }
+
+        "not render an error summary" in {
+
+          val doc = asDocument(createView(form))
+          assertNotRenderedById(doc, "error-summary-heading")
+        }
+      }
+
+      "rendered with any error" must {
+
+        "show an error prefix in the browser title" in {
+
+          val doc = asDocument(createView(form.withError(error)))
+          assertEqualsValue(
+            doc = doc,
+            cssSelector = "title",
+            expectedValue = s"""${messages("error.browser.title.prefix")} ${messages(s"$messageKeyPrefix.title")} - ${frontendAppConfig.serviceTitle}"""
+          )        }
+      }
+
+      for (field <- fields) {
+
+        s"rendered with an error with field '$field'" must {
+
+          "show an error summary" in {
+
+            val doc = asDocument(createView(form.withError(FormError(field, "error"))))
+            assertRenderedById(doc, "error-summary-heading")
+          }
+
+          s"show an error in the label for field '$field'" in {
+
+            val doc = asDocument(createView(form.withError(FormError(field, "error"))))
+            val errorSpan = doc.getElementsByClass("error-message").first
+            errorSpan.parent.attr("for") mustBe field
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/views/behaviours/NewStringViewBehaviours.scala
+++ b/test/views/behaviours/NewStringViewBehaviours.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.behaviours
+
+import play.api.data.Form
+import play.twirl.api.HtmlFormat
+
+trait NewStringViewBehaviours extends NewQuestionViewBehaviours[String] {
+
+  val answer = "answer"
+
+  def stringPage(form: Form[String],
+                 createView: Form[String] => HtmlFormat.Appendable,
+                 messageKeyPrefix: String,
+                 expectedFormAction: String,
+                 expectedHintKey: Option[String] = None) = {
+
+    "behave like a page with a string value field" when {
+
+      "rendered" must {
+
+        "contain a label for the value" in {
+
+          val doc = asDocument(createView(form))
+          val expectedHintText = expectedHintKey map (k => messages(k))
+          assertContainsLabel(doc, "value", messages(s"$messageKeyPrefix.heading"), expectedHintText)
+        }
+
+        "contain an input for the value" in {
+
+          val doc = asDocument(createView(form))
+          assertRenderedById(doc, "value")
+        }
+      }
+
+      "rendered with a valid form" must {
+
+        "include the form's value in the value input" in {
+
+          val doc = asDocument(createView(form.fill(answer)))
+          doc.getElementById("value").attr("value") mustBe answer
+        }
+      }
+
+      "rendered with an error" must {
+
+        "show an error summary" in {
+
+          val doc = asDocument(createView(form.withError(error)))
+          assertRenderedById(doc, "error-summary-heading")
+        }
+
+        "show an error in the value field's label" in {
+
+          val doc = asDocument(createView(form.withError(error)))
+          val errorSpan = doc.getElementsByClass("error-message").first
+          errorSpan.text mustBe messages(errorMessage)
+        }
+
+        "show an error prefix in the browser title" in {
+
+          val doc = asDocument(createView(form.withError(error)))
+          assertEqualsValue(
+            doc = doc,
+            cssSelector = "title",
+            expectedValue = s"""${messages("error.browser.title.prefix")} ${messages(s"$messageKeyPrefix.title")} - ${frontendAppConfig.serviceTitle}"""
+          )
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# DL-9563 - WhichSubscriptionView

Removed `contentAsString` equivalence checks; a CSP Nonce was added which breaks them.

## Checklist

*Reviewee* (Replace with your name)
 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
